### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.5"
 authors = ["Nathan Fiscaletti <nate.fiscaletti@gmail.com>"]
 edition = "2018"
 documentation = "https://docs.rs/tokenbucket/"
-homepage = "https://github.com/nathan-fiscaletti/tokenbucket-rs"
+repository = "https://github.com/nathan-fiscaletti/tokenbucket-rs"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.